### PR TITLE
Remove esm dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+esm
 coverage
 *.log

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ npm test
 
 Here are the available command line arguments:
 
-| Argument     | Usage                                                                                                                                                                                                                                                 | Default                                                 |
-|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| testPattern  | The regex pattern Tead uses to detect test files. Defaults to files ending with `test.js` or `spec.js` not in `node_modules`.                                                                                                                         | <code>^((?!node_modules).)*(test&#124;spec)\.js$</code> |
-| watch        | Watch files for changes and rerun tests. Output is limited to only failing tests and overall passing/failing counts.                                                                                                                                  |                                                         |
-| watchPattern | The regex pattern Tead uses when in watch mode to match which file changes should rereun tests. Defaults to files ending with `.js` not in `node_modules`.                                                                                            | <code>^((?!node_modules).)*\.js$</code>                 |
-| coverage     | Test coverage information is collected, reported in the output, and written to the `/coverage` folder. This argument makes use of `npx`, so the same [caveat](#npx) about Node.js versions above applies. Requires a [local install](#local) of Tead. |                                                         |
+| Argument     | Usage                                                                                                                                                                                                     | Default                                                  |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| testPattern  | The regex pattern Tead uses to detect test files. Defaults to files ending with `test.js` or `spec.js` not in `node_modules`.                                                                             | <code>^((?!node_modules).)\*(test&#124;spec)\.js$</code> |
+| watch        | Watch files for changes and rerun tests. Output is limited to only failing tests and overall passing/failing counts.                                                                                      |                                                          |
+| watchPattern | The regex pattern Tead uses when in watch mode to match which file changes should rereun tests. Defaults to files ending with `.js` not in `node_modules`.                                                | <code>^((?!node_modules).)\*\.js$</code>                 |
+| coverage     | Test coverage information is collected, reported in the output, and written to the `/coverage` folder. This argument makes use of `npx`, so the same [caveat](#npx) about Node.js versions above applies. |                                                          |
 
 Each argument is passed in the form `--argument=value`. Here is an example:
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "tead",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Lighting the way to simpler testing",
   "files": [
-    "src"
+    "src",
+    "esm"
   ],
   "main": "./src/index.js",
   "bin": {
@@ -12,14 +13,14 @@
   "engines": {
     "node": ">=6.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "esm": "=3.0.72"
   },
   "scripts": {
-    "clean": "npx rimraf coverage node_modules",
+    "clean": "npx rimraf node_modules esm coverage",
     "format": "npx prettier --write {src,test}/**/*.js",
     "format:check": "npx prettier --list-different {src,test}/**/*.js",
-    "pretest": "node test/bootstrap",
+    "pretest": "npx rimraf esm && npx cp -r node_modules/esm . && node test/bootstrap",
     "test": "node src/tead.js --coverage",
     "test:watch": "node src/tead.js --watch",
     "prepare": "npm run format:check && npm t",

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ module.exports = options => {
   } = options;
   if (coverage) {
     spawn(
-      `npx nyc --require esm --temp-directory coverage -r lcov -r text node ${__dirname}/tead.js "--testPattern=${testPattern}"`,
+      `npx nyc --require ${__dirname}/../esm/esm.js --temp-directory coverage -r lcov -r text node ${__dirname}/tead.js "--testPattern=${testPattern}"`,
       {
         shell: true,
         stdio: "inherit"

--- a/src/tead.js
+++ b/src/tead.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 const options = require("./options")();
-require = require("esm")(module);
+require = require("../esm/esm")(module);
 
 require("./")(options);


### PR DESCRIPTION
Include a copy of the published `esm` package and move it from `dependencies` to `devDependencies `.

This removes the need to have local install in order for the require used by coverage to work.

Closes #22.