### PR TITLE
watch mode runs all the latest code

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ npm test
 
 Here are the available command line arguments:
 
-| Argument     | Usage                                                                                                                                                      | Default                                                   |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| testPattern  | The regex pattern Tead uses to detect test files. Defaults to files ending with `test.js` or `spec.js` not in `node_modules`.                              | <code>^((?!node_modules).)\*(test&#124;spec)\.js\$</code> |
-| watch        | Watch files for changes and rerun tests. Output is limited to only failing tests and overall passing/failing counts.                                       |                                                           |
-| watchPattern | The regex pattern Tead uses when in watch mode to match which file changes should rereun tests. Defaults to files ending with `.js` not in `node_modules`. | <code>^((?!node_modules).)\*\.js\$</code>                 |
-| coverage     | Test coverage information is collected, reported in the output, and written to the `/coverage` folder.                                                     |                                                           |
+| Argument     | Usage                                                                                                                                                      | Default                                                         |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| testPattern  | The regex pattern Tead uses to detect test files. Defaults to files ending with `test.js` or `spec.js` not in `node_modules`.                              | <code>^((?!node_modules).)\*(\\.\|\\/)(test\|spec)\\.js$</code> |
+| watch        | Watch files for changes and rerun tests. Output is limited to only failing tests and overall passing/failing counts.                                       |                                                                 |
+| watchPattern | The regex pattern Tead uses when in watch mode to match which file changes should rereun tests. Defaults to files ending with `.js` not in `node_modules`. | <code>^((?!node_modules).)\*\.js\$</code>                       |
+| coverage     | Test coverage information is collected, reported in the output, and written to the `/coverage` folder.                                                     |                                                                 |
 
 Each argument is passed in the form `--argument=value`. Here is an example:
 

--- a/src/resolveImportToLatest.js
+++ b/src/resolveImportToLatest.js
@@ -1,0 +1,14 @@
+export async function resolve(specifier, context, nextResolve) {
+  const nextResult = await nextResolve(specifier, context);
+  if (nextResult.url.startsWith("file://")) {
+    // appending a unique id to imports is the most reliable way
+    // to make sure the latest module code is used each time
+    const url = new URL(nextResult.url);
+    url.searchParams.set("v", Date.now());
+    return {
+      shortCircuit: true,
+      url: url.href
+    };
+  }
+  return nextResult;
+}


### PR DESCRIPTION
ESM doesn't allow hooking into the module cache, so we work around this in the same way that the [imports for test files work](https://github.com/teadjs/tead/blob/1db42b4afd4952ff7b435c76b37ca8b4cb5d1c12/src/index.js#L20-L23), by adding a custom [resolve](https://nodejs.org/api/module.html#resolvespecifier-context-nextresolve) that appends a unique query param to all imported filesystem modules

also fixed an issue with the default test pattern regex

closes #33